### PR TITLE
Remove Chat Header

### DIFF
--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -276,12 +276,6 @@ export class Chat extends React.Component<ChatProps, {}> {
                     onKeyDownCapture={ this._handleKeyDownCapture }
                     ref={ this._saveChatviewPanelRef }
                 >
-                    {
-                        !!state.format.chatTitle &&
-                            <div className="wc-header">
-                                <span>{ typeof state.format.chatTitle === 'string' ? state.format.chatTitle : state.format.strings.title }</span>
-                            </div>
-                    }
                     <MessagePane>
                         <History
                             onCardAction={ this._handleCardAction }

--- a/src/scss/botchat.scss
+++ b/src/scss/botchat.scss
@@ -156,7 +156,7 @@
 
     .wc-message-pane.show-actions {
         .wc-message-groups {
-            top: $headerTotalHeight + $actionsHeight;
+            top: 0;
             transform: translateY(-$actionsHeight);
         }
         .wc-suggested-actions {


### PR DESCRIPTION
## Background
Removed the chat header so that we're more inlined w/ the original web bot styling. In addition, when the bot is iframed, we add a chat header. 

![screen shot 2018-07-09 at 6 34 57 am](https://user-images.githubusercontent.com/1294288/42453643-36af49d0-8342-11e8-88bf-e0a6eb3b8931.png)


## Changes
* `Chat.tsx`: Remove Chat header
* `botchat.scss`: removed top pixel setting
