### PR TITLE
Don't use backtick string interpolation to support older browsers

### DIFF
--- a/samples/release/bot.html
+++ b/samples/release/bot.html
@@ -58,7 +58,7 @@
 
       }
 
-      var actionEndpointUrl = `${ACTION_ENDPOINT_URL}/api/action/welcome.greeting?userId=${userId}&vendorId=${VENDOR_ID}`;
+      var actionEndpointUrl = ACTION_ENDPOINT_URL + '/api/action/welcome.greeting?userId=' + userId + '&vendorId=' + VENDOR_ID;
 
       BotChat.App({
         secret: SECRET,


### PR DESCRIPTION
Fix IE11 Error