### PR TITLE
[CAR-1810] Load the webchat if facebook fails

### DIFF
--- a/samples/release/carla-v2.js
+++ b/samples/release/carla-v2.js
@@ -393,6 +393,12 @@ var carlaBot = (function () {
           }
         });
 
+        FB.Event.subscribe('xfbml.render', () => {
+          if(_fbRoot.style.display === 'none'){
+            _chatToDisplay("web");
+          }
+        });
+
         // Subscribe To Authentication Events Especially After When User Gives Authorization To App
         FB.Event.subscribe('auth.statusChange', function(response) {
           if (response.status === 'connected') {


### PR DESCRIPTION
/* Please update CHANGELOG.md. Under [Unreleased] section, describe your changes under 80 characters */
https://carlabs.atlassian.net/browse/CAR-1810
This is a hack that appears to fix the issue.
And I have tested it up to 100 times both on a blocked and allowed site and it works as expected
It works because Facebook calls that event very very late and by then the chat should have been loaded if allowed. So I am checking if facebook is not displayed by then to now render our webchat